### PR TITLE
Add `read_metadata()` function

### DIFF
--- a/csvy/__init__.py
+++ b/csvy/__init__.py
@@ -2,5 +2,5 @@
 Python reader/writer for CSV files with YAML header information.
 """
 __version__ = "0.2.0"
-from .readers import read_to_array, read_to_dataframe  # noqa: F401
+from .readers import read_header, read_to_array, read_to_dataframe  # noqa: F401
 from .writers import write  # noqa: F401

--- a/csvy/__init__.py
+++ b/csvy/__init__.py
@@ -2,5 +2,10 @@
 Python reader/writer for CSV files with YAML header information.
 """
 __version__ = "0.2.0"
-from .readers import read_header, read_to_array, read_to_dataframe  # noqa: F401
+from .readers import (  # noqa: F401
+    read_header,
+    read_metadata,
+    read_to_array,
+    read_to_dataframe,
+)
 from .writers import write  # noqa: F401

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -79,6 +79,22 @@ def read_header(
     return yaml.safe_load("".join(header), **kwargs), nlines, comment
 
 
+def read_metadata(
+    filename: Union[Path, str], marker: str = "---", **kwargs: Any
+) -> Dict[str, Any]:
+    """Read the yaml-formatted metadata from a file.
+
+    Args:
+        filename: Name of the file to read the header from.
+        marker: The marker characters that indicate the yaml header.
+        **kwargs: Arguments to pass to 'yaml.safe_load'.
+
+    Returns:
+        The metadata stored in the header.
+    """
+    return read_header(filename, marker, **kwargs)[0]
+
+
 def read_to_array(
     filename: Union[Path, str],
     marker: str = "---",

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 
@@ -28,6 +30,20 @@ def test_get_header(data_path, data_comment_path):
     assert comment == "# "
 
     assert header == header2
+
+
+@patch("csvy.readers.read_header")
+def test_read_metadata(read_header_mock, data_path):
+    from csvy import read_metadata
+
+    read_header_mock.return_value = ("a", "b")
+
+    filename = "test.csv"
+    marker = "!!!"
+    kwargs = {"key": "value"}
+    assert read_metadata(filename=filename, marker=marker, **kwargs) == "a"
+
+    read_header_mock.assert_called_once_with(filename, marker, **kwargs)
 
 
 def test_read_to_array(array_data_path):


### PR DESCRIPTION
Closes #25.

It would be handy to be able to read just the metadata from a data file without having to load everything else. I've added a new `read_metadata()` function to do this.