### PR TITLE
Fix markdownlint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
     rev: v0.33.0
     hooks:
       - id: markdownlint
-        args: ["--disable", "MD013"]
+        args: ["--disable", "MD013", "MD041", "--"]


### PR DESCRIPTION
The markdownlint hook we've been using has broken arguments to it. See: ImperialCollegeLondon/poetry_template_2#41

I re-ran the hooks and the markdown seems fine though.