### PR TITLE
Set UTF-8 as default encoding when reading and writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ You can also instruct a writer to use line buffering, instead of the usual chunk
 Finally, you can control the character(s) used to indicate comments by setting the
 `comment` keyword when writing a file. By default, there is no character (""). During reading, the comment character is found atomatically.
 
+Note that, by default, these reader functions will assume UTF-8 encoding. You can choose a
+different character encoding by setting the `encoding` keyword argument to any of these
+reader or writer functions. For example, on Windows, Python will assume Windows-1252 encoding,
+which can be specified via `encoding='cp1252'`.
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ YAML-formatted header, respectively.
 You can also instruct a writer to use line buffering, instead of the usual chunk buffering.
 
 Finally, you can control the character(s) used to indicate comments by setting the
-`comment` keyword when writing a file. By default, there is no character (""). During reading, the comment character is found atomatically.
+`comment` keyword when writing a file. By default, there is no character ("").
+During reading, the comment character is found automatically.
 
 Note that, by default, these reader functions will assume UTF-8 encoding. You can choose a
 different character encoding by setting the `encoding` keyword argument to any of these
-reader or writer functions. For example, on Windows, Python will assume Windows-1252 encoding,
+reader or writer functions. For example, on Windows, Windows-1252 encoding is often used,
 which can be specified via `encoding='cp1252'`.
 
 ## Contributors ✨

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
@@ -195,7 +195,7 @@ def read_to_dataframe(
 def read_to_polars(
     filename: Path | str,
     marker: str = "---",
-    encoding: str = "utf-8",
+    encoding: Literal["utf8", "utf8-lossy"] = "utf8",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
     eager: bool = False,

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -219,10 +219,14 @@ def read_to_polars(
 
     Raises:
         ModuleNotFoundError: If polars is not found.
+        ValueError: If an invalid character encoding is specified.
 
     Returns:
         Tuple containing: The polars LazyFrame and the header as a dictionary.
     """
+    if encoding not in ("utf8", "utf8-lossy"):
+        raise ValueError("Encoding must be either 'utf8' or 'utf8-lossy'")
+
     if LazyFrame is None:
         raise ModuleNotFoundError(
             "Module polars is not present. Install it to read data into DataFrame."
@@ -231,7 +235,7 @@ def read_to_polars(
 
     yaml_options = yaml_options if yaml_options is not None else {}
     header, nlines, comment = read_header(
-        filename, marker=marker, encoding=encoding, **yaml_options
+        filename, marker=marker, encoding="utf-8", **yaml_options
     )
 
     options = csv_options.copy() if csv_options is not None else {}

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -76,7 +76,7 @@ def read_header(
     markers = 0
     nlines = 0
     comment = ""
-    with Path(filename).open("r") as f:
+    with Path(filename).open("r", encoding="utf-8") as f:
         for line in f:
             if nlines == 0:
                 comment = get_comment(line, marker=marker)
@@ -258,7 +258,7 @@ def read_to_list(
     options = csv_options.copy() if csv_options is not None else {}
 
     data = []
-    with open(filename, newline="") as csvfile:
+    with open(filename, encoding="utf-8", newline="") as csvfile:
         csvreader = csv.reader(csvfile, **options)
 
         for _ in range(nlines):

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -147,7 +147,7 @@ def read_to_array(
     options = csv_options.copy() if csv_options is not None else {}
     options["skiprows"] = nlines + options.get("skiprows", 0)
     options["comments"] = comment[0] if len(comment) >= 1 else "#"
-    return np.loadtxt(filename, **options), header
+    return np.loadtxt(filename, encoding=encoding, **options), header
 
 
 def read_to_dataframe(
@@ -189,7 +189,7 @@ def read_to_dataframe(
     options = csv_options.copy() if csv_options is not None else {}
     options["skiprows"] = nlines
     options["comment"] = comment[0] if len(comment) >= 1 else None
-    return pd.read_csv(filename, **options), header
+    return pd.read_csv(filename, encoding=encoding, **options), header
 
 
 def read_to_polars(
@@ -238,7 +238,7 @@ def read_to_polars(
     options["skip_rows"] = nlines
     options["comment_prefix"] = comment[0] if len(comment) >= 1 else None
 
-    lf = pl.scan_csv(filename, **options)
+    lf = pl.scan_csv(filename, encoding=encoding, **options)
     if eager:
         return lf.collect(), header
     return lf, header

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -276,7 +276,7 @@ def read_to_list(
     options = csv_options.copy() if csv_options is not None else {}
 
     data = []
-    with open(filename, encoding="utf-8", newline="") as csvfile:
+    with open(filename, encoding=encoding, newline="") as csvfile:
         csvreader = csv.reader(csvfile, **options)
 
         for _ in range(nlines):

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -59,13 +59,14 @@ def get_comment(line: str, marker: str = "---") -> str:
 
 
 def read_header(
-    filename: Path | str, marker: str = "---", **kwargs: Any
+    filename: Path | str, marker: str = "---", encoding: str = "utf-8", **kwargs: Any
 ) -> tuple[dict[str, Any], int, str]:
     """Read the yaml-formatted header from a file.
 
     Args:
         filename: Name of the file to read the header from.
         marker: The marker characters that indicate the yaml header.
+        encoding: The character encoding in the file to read.
         **kwargs: Arguments to pass to 'yaml.safe_load'.
 
     Returns:
@@ -76,7 +77,7 @@ def read_header(
     markers = 0
     nlines = 0
     comment = ""
-    with Path(filename).open("r", encoding="utf-8") as f:
+    with Path(filename).open("r", encoding=encoding) as f:
         for line in f:
             if nlines == 0:
                 comment = get_comment(line, marker=marker)
@@ -94,24 +95,26 @@ def read_header(
 
 
 def read_metadata(
-    filename: Path | str, marker: str = "---", **kwargs: Any
+    filename: Path | str, marker: str = "---", encoding: str = "utf-8", **kwargs: Any
 ) -> dict[str, Any]:
     """Read the yaml-formatted metadata from a file.
 
     Args:
         filename: Name of the file to read the header from.
         marker: The marker characters that indicate the yaml header.
+        encoding: The character encoding in the file to read.
         **kwargs: Arguments to pass to 'yaml.safe_load'.
 
     Returns:
         The metadata stored in the header.
     """
-    return read_header(filename, marker, **kwargs)[0]
+    return read_header(filename, marker, encoding, **kwargs)[0]
 
 
 def read_to_array(
     filename: Path | str,
     marker: str = "---",
+    encoding: str = "utf-8",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
 ) -> tuple[NDArray, dict[str, Any]]:
@@ -120,6 +123,7 @@ def read_to_array(
     Args:
         filename:  Name of the file to read.
         marker: The marker characters that indicate the yaml header.
+        encoding: The character encoding in the file to read.
         csv_options: Options to pass to np.loadtxt.
         yaml_options: Options to pass to yaml.safe_load.
 
@@ -136,7 +140,9 @@ def read_to_array(
     import numpy as np
 
     yaml_options = yaml_options if yaml_options is not None else {}
-    header, nlines, comment = read_header(filename, marker=marker, **yaml_options)
+    header, nlines, comment = read_header(
+        filename, marker=marker, encoding=encoding, **yaml_options
+    )
 
     options = csv_options.copy() if csv_options is not None else {}
     options["skiprows"] = nlines + options.get("skiprows", 0)
@@ -147,6 +153,7 @@ def read_to_array(
 def read_to_dataframe(
     filename: Path | str,
     marker: str = "---",
+    encoding: str = "utf-8",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
 ) -> tuple[DataFrame, dict[str, Any]]:
@@ -158,6 +165,7 @@ def read_to_dataframe(
     Args:
         filename:  Name of the file to read.
         marker: The marker characters that indicate the yaml header.
+        encoding: The character encoding in the file to read.
         csv_options: Options to pass to pd.read_csv.
         yaml_options: Options to pass to yaml.safe_load.
 
@@ -174,7 +182,9 @@ def read_to_dataframe(
     import pandas as pd
 
     yaml_options = yaml_options if yaml_options is not None else {}
-    header, nlines, comment = read_header(filename, marker=marker, **yaml_options)
+    header, nlines, comment = read_header(
+        filename, marker=marker, encoding=encoding, **yaml_options
+    )
 
     options = csv_options.copy() if csv_options is not None else {}
     options["skiprows"] = nlines
@@ -185,6 +195,7 @@ def read_to_dataframe(
 def read_to_polars(
     filename: Path | str,
     marker: str = "---",
+    encoding: str = "utf-8",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
     eager: bool = False,
@@ -201,6 +212,7 @@ def read_to_polars(
     Args:
         filename:  Name of the file to read.
         marker: The marker characters that indicate the yaml header.
+        encoding: The character encoding in the file to read.
         csv_options: Options to pass to pl.scan_csv.
         yaml_options: Options to pass to yaml.safe_load.
         eager: Whether to load the data into memory.
@@ -218,7 +230,9 @@ def read_to_polars(
     import polars as pl
 
     yaml_options = yaml_options if yaml_options is not None else {}
-    header, nlines, comment = read_header(filename, marker=marker, **yaml_options)
+    header, nlines, comment = read_header(
+        filename, marker=marker, encoding=encoding, **yaml_options
+    )
 
     options = csv_options.copy() if csv_options is not None else {}
     options["skip_rows"] = nlines
@@ -233,6 +247,7 @@ def read_to_polars(
 def read_to_list(
     filename: Path | str,
     marker: str = "---",
+    encoding: str = "utf-8",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
 ) -> tuple[list[list], dict[str, Any]]:
@@ -241,6 +256,7 @@ def read_to_list(
     Args:
         filename: Name of the file to read.
         marker: The marker characters that indicate the yaml header.
+        encoding: The character encoding in the file to read.
         csv_options: Options to pass to csv.reader.
         yaml_options: Options to pass to yaml.safe_load.
 
@@ -253,7 +269,9 @@ def read_to_list(
     import csv
 
     yaml_options = yaml_options if yaml_options is not None else {}
-    header, nlines, _ = read_header(filename, marker=marker, **yaml_options)
+    header, nlines, _ = read_header(
+        filename, marker=marker, encoding=encoding, **yaml_options
+    )
 
     options = csv_options.copy() if csv_options is not None else {}
 

--- a/csvy/writers.py
+++ b/csvy/writers.py
@@ -33,6 +33,7 @@ def write(
     data: Any,
     header: dict[str, Any],
     comment: str = "",
+    encoding: str = "utf-8",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
 ) -> None:
@@ -44,6 +45,7 @@ def write(
         data: The data to add to the file.
         header: Dictionary with the header information to save.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         csv_options: Arguments to pass to the CSV writer, being this `savetxt`, panda's
             `to_csv` or something else. Mind that any argument related to the character
             to indicate a comment or header line will be ignored.
@@ -53,8 +55,8 @@ def write(
     csv_options = csv_options if csv_options is not None else {}
     yaml_options = yaml_options if yaml_options is not None else {}
 
-    write_header(filename, header, comment, **yaml_options)
-    write_data(filename, data, comment, **csv_options)
+    write_header(filename, header, comment, encoding, **yaml_options)
+    write_data(filename, data, comment, encoding, **csv_options)
 
 
 class Writer:
@@ -68,6 +70,7 @@ class Writer:
         filename: Path | str,
         header: dict[str, Any],
         comment: str = "",
+        encoding: str = "utf-8",
         csv_options: dict[str, Any] | None = None,
         yaml_options: dict[str, Any] | None = None,
         line_buffering: bool = False,
@@ -78,6 +81,7 @@ class Writer:
             filename: Path to file. If it exists it will be overwritten.
             header: Dictionary with the header information to save.
             comment: String to use to mark the header lines as comments.
+            encoding: The character encoding to use when writing to file.
             csv_options: Arguments to pass to csv.writer()
             yaml_options: Arguments to pass to the 'yaml.safe_dump' function to control
                 writing the header.
@@ -93,9 +97,9 @@ class Writer:
 
         # Newline must be "" as per csv.writer's documentation
         self._file = Path(filename).open(
-            "w", encoding="utf-8", newline="", buffering=buffering
+            "w", encoding=encoding, newline="", buffering=buffering
         )
-        write_header(self._file, header, comment, **yaml_options)
+        write_header(self._file, header, comment, encoding, **yaml_options)
 
         self._writer = csv.writer(self._file, **csv_options)
 
@@ -124,6 +128,7 @@ def write_header(
     file: Path | str | TextIOBase,
     header: dict[str, Any],
     comment: str = "",
+    encoding: str = "utf-8",
     **kwargs: Any,
 ) -> None:
     """Writes the header dictionary into the file with lines starting with comment.
@@ -132,11 +137,12 @@ def write_header(
         file: File handle or path to file. Will be overwritten if it exists.
         header: Dictionary with the header information to save.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         **kwargs: Arguments to pass to 'yaml.safe_dump'. If "sort_keys" is not one of
             arguments, it will be set to sort_keys=False.
     """
     if not isinstance(file, TextIOBase):
-        with Path(file).open("w", encoding="utf-8") as f:
+        with Path(file).open("w", encoding=encoding) as f:
             write_header(f, header, comment, **kwargs)
             return
 
@@ -151,7 +157,11 @@ def write_header(
 
 
 def write_data(
-    filename: Path | str, data: Any, comment: str = "", **kwargs: Any
+    filename: Path | str,
+    data: Any,
+    comment: str = "",
+    encoding: str = "utf-8",
+    **kwargs: Any,
 ) -> None:
     """Writes the tabular data to the chosen file, adding it after the header.
 
@@ -163,18 +173,23 @@ def write_data(
             package. If it is a numpy array, the `savetxt` will be used, while if it is
             a pandas Dataframe, the `to_csv` method will be used.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         **kwargs: Arguments to be passed to the underlaying saving method.
     """
     for fun in KNOWN_WRITERS:
         if fun(filename, data, comment, **kwargs):
             return
 
-    write_csv(filename, data, comment, **kwargs)
+    write_csv(filename, data, comment, encoding, **kwargs)
 
 
 @register_writer
 def write_numpy(
-    filename: Path | str, data: Any, comment: str = "", **kwargs: Any
+    filename: Path | str,
+    data: Any,
+    comment: str = "",
+    encoding: str = "utf-8",
+    **kwargs: Any,
 ) -> bool:
     """Writes the numpy array to the chosen file, adding it after the header.
 
@@ -184,6 +199,7 @@ def write_numpy(
         data: The data. If it is a numpy array, it will be saved, otherwise nothing is
             done.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         **kwargs: Arguments to be passed to the underlaying saving method.
 
     Return:
@@ -194,7 +210,7 @@ def write_numpy(
 
         kwargs["comments"] = comment
         if isinstance(data, np.ndarray):
-            with open(filename, "a", encoding="utf-8") as f:
+            with open(filename, "a", encoding=encoding) as f:
                 np.savetxt(f, data, **kwargs)
 
             return True
@@ -207,7 +223,11 @@ def write_numpy(
 
 @register_writer
 def write_pandas(
-    filename: Path | str, data: Any, comment: str = "", **kwargs: Any
+    filename: Path | str,
+    data: Any,
+    comment: str = "",
+    encoding: str = "utf-8",
+    **kwargs: Any,
 ) -> bool:
     """Writes the pandas dataframe to the chosen file, adding it after the header.
 
@@ -217,6 +237,7 @@ def write_pandas(
         data: The data. If it is a pandas dataframe, it will be saved, otherwise nothing
             is done.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         **kwargs: Arguments to be passed to the underlaying saving method.
 
     Returns:
@@ -226,7 +247,7 @@ def write_pandas(
         import pandas as pd
 
         if isinstance(data, pd.DataFrame):
-            with open(filename, "a", encoding="utf-8", newline="") as f:
+            with open(filename, "a", encoding=encoding, newline="") as f:
                 data.to_csv(f, **kwargs)
 
             return True
@@ -239,7 +260,11 @@ def write_pandas(
 
 @register_writer
 def write_polars(
-    filename: Path | str, data: Any, comment: str = "", **kwargs: Any
+    filename: Path | str,
+    data: Any,
+    comment: str = "",
+    encoding: str = "utf-8",
+    **kwargs: Any,
 ) -> bool:
     """Writes the polars dataframe to the chosen file, adding it after the header.
 
@@ -249,6 +274,7 @@ def write_polars(
         data: The data. If it is a polars DataFrame or LazyFrame, it will be saved,
             otherwise nothing is done.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         **kwargs: Arguments to be passed to the underlaying saving method.
 
     Returns:
@@ -262,7 +288,7 @@ def write_polars(
             # collect the data into a DataFrame first
             data = data.collect()
         if isinstance(data, pl.DataFrame):
-            with open(filename, "a", encoding="utf-8", newline="") as f:
+            with open(filename, "a", encoding=encoding, newline="") as f:
                 data.write_csv(f, **kwargs)
 
             return True
@@ -274,7 +300,11 @@ def write_polars(
 
 
 def write_csv(
-    filename: Path | str, data: Any, comment: str = "", **kwargs: Any
+    filename: Path | str,
+    data: Any,
+    comment: str = "",
+    encoding: str = "utf-8",
+    **kwargs: Any,
 ) -> bool:
     """Writes the tabular to the chosen file, adding it after the header.
 
@@ -284,12 +314,13 @@ def write_csv(
         data: The data. Can have anything that counts as a sequence. Each component of
             the sequence will be saved in a different row.
         comment: String to use to mark the header lines as comments.
+        encoding: The character encoding to use in the file to write.
         **kwargs: Arguments to be passed to the underlaying saving method.
 
     Returns:
         True if the writer worked, False otherwise.
     """
-    with open(filename, "a", encoding="utf-8", newline="") as f:
+    with open(filename, "a", encoding=encoding, newline="") as f:
         writer = csv.writer(f, **kwargs)
         for row in data:
             writer.writerow(row)

--- a/csvy/writers.py
+++ b/csvy/writers.py
@@ -92,7 +92,9 @@ class Writer:
         buffering = 1 if line_buffering else -1
 
         # Newline must be "" as per csv.writer's documentation
-        self._file = Path(filename).open("w", newline="", buffering=buffering)
+        self._file = Path(filename).open(
+            "w", encoding="utf-8", newline="", buffering=buffering
+        )
         write_header(self._file, header, comment, **yaml_options)
 
         self._writer = csv.writer(self._file, **csv_options)
@@ -134,7 +136,7 @@ def write_header(
             arguments, it will be set to sort_keys=False.
     """
     if not isinstance(file, TextIOBase):
-        with Path(file).open("w") as f:
+        with Path(file).open("w", encoding="utf-8") as f:
             write_header(f, header, comment, **kwargs)
             return
 
@@ -192,7 +194,7 @@ def write_numpy(
 
         kwargs["comments"] = comment
         if isinstance(data, np.ndarray):
-            with open(filename, "a") as f:
+            with open(filename, "a", encoding="utf-8") as f:
                 np.savetxt(f, data, **kwargs)
 
             return True
@@ -224,7 +226,7 @@ def write_pandas(
         import pandas as pd
 
         if isinstance(data, pd.DataFrame):
-            with open(filename, "a", newline="") as f:
+            with open(filename, "a", encoding="utf-8", newline="") as f:
                 data.to_csv(f, **kwargs)
 
             return True
@@ -260,7 +262,7 @@ def write_polars(
             # collect the data into a DataFrame first
             data = data.collect()
         if isinstance(data, pl.DataFrame):
-            with open(filename, "a", newline="") as f:
+            with open(filename, "a", encoding="utf-8", newline="") as f:
                 data.write_csv(f, **kwargs)
 
             return True
@@ -287,7 +289,7 @@ def write_csv(
     Returns:
         True if the writer worked, False otherwise.
     """
-    with open(filename, "a", newline="") as f:
+    with open(filename, "a", encoding="utf-8", newline="") as f:
         writer = csv.writer(f, **kwargs)
         for row in data:
             writer.writerow(row)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -45,10 +45,14 @@ def test_read_metadata(read_header_mock, data_path):
 
     filename = "test.csv"
     marker = "!!!"
+    encoding = "hieroglyphics"
     kwargs = {"key": "value"}
-    assert read_metadata(filename=filename, marker=marker, **kwargs) == "a"
+    assert (
+        read_metadata(filename=filename, marker=marker, encoding=encoding, **kwargs)
+        == "a"
+    )
 
-    read_header_mock.assert_called_once_with(filename, marker, **kwargs)
+    read_header_mock.assert_called_once_with(filename, marker, encoding, **kwargs)
 
 
 def test_read_to_array(array_data_path):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -119,7 +119,7 @@ def test_read_to_polars(data_path):
         read_to_polars(data_path)
 
     with pytest.raises(ValueError):
-        read_to_polars(data_path, encoding="utf-9")
+        read_to_polars(data_path, encoding="utf-9")  # type: ignore [arg-type]
 
 
 def test_read_to_list(array_data_path):

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -118,6 +118,9 @@ def test_read_to_polars(data_path):
     with pytest.raises(ModuleNotFoundError):
         read_to_polars(data_path)
 
+    with pytest.raises(ValueError):
+        read_to_polars(data_path, encoding="utf-9")
+
 
 def test_read_to_list(array_data_path):
     """Test the read_to_list function."""

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -145,12 +145,13 @@ def test_writer(mock_write_header, mock_csv_writer, csv_options, yaml_options, t
     filename = tmpdir / "some_file.csv"
     header = {"name": "HAL"}
     comment = "# "
+    encoding = "utf-8"
 
-    writer = Writer(filename, header, comment, csv_options, yaml_options)
+    writer = Writer(filename, header, comment, encoding, csv_options, yaml_options)
     csv_options = csv_options or {}
     yaml_options = yaml_options or {}
     mock_write_header.assert_called_once_with(
-        writer._file, header, comment, **yaml_options
+        writer._file, header, comment, encoding, **yaml_options
     )
 
     mock_csv_writer.assert_called_once_with(writer._file, **csv_options)
@@ -221,6 +222,7 @@ def test_write(mock_write_data, mock_write_header):
     data = [[1, 2], [3, 4]]
     header = {"name": "HAL"}
     comment = "# "
+    encoding = "encoding"
     csv_options = {"delimiter": ","}
     yaml_options = {"sort_keys": False}
 
@@ -229,12 +231,17 @@ def test_write(mock_write_data, mock_write_header):
         data,
         header,
         comment,
+        encoding,
         csv_options=csv_options,
         yaml_options=yaml_options,
     )
 
-    mock_write_header.assert_called_once_with(filename, header, comment, **yaml_options)
-    mock_write_data.assert_called_once_with(filename, data, comment, **csv_options)
+    mock_write_header.assert_called_once_with(
+        filename, header, comment, encoding, **yaml_options
+    )
+    mock_write_data.assert_called_once_with(
+        filename, data, comment, encoding, **csv_options
+    )
 
 
 @patch("csvy.writers.write_csv")
@@ -245,16 +252,19 @@ def test_write_data(mock_write_csv):
     filename = "here.csv"
     data = [[1, 2], [3, 4]]
     comment = "# "
+    encoding = "encoding"
     csv_options = {"delimiter": ","}
 
     KNOWN_WRITERS.clear()
     KNOWN_WRITERS.append(MagicMock(return_value=True))
-    write_data(filename, data, comment, **csv_options)
+    write_data(filename, data, comment, encoding, **csv_options)
     KNOWN_WRITERS[0].assert_called_once_with(filename, data, comment, **csv_options)
     mock_write_csv.assert_not_called()
 
     KNOWN_WRITERS.clear()
     KNOWN_WRITERS.append(MagicMock(return_value=False))
-    write_data(filename, data, comment, **csv_options)
+    write_data(filename, data, comment, encoding, **csv_options)
     KNOWN_WRITERS[0].assert_called_once_with(filename, data, comment, **csv_options)
-    mock_write_csv.assert_called_once_with(filename, data, comment, **csv_options)
+    mock_write_csv.assert_called_once_with(
+        filename, data, comment, encoding, **csv_options
+    )

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -269,4 +269,6 @@ def test_write_data(mock_write_csv):
     KNOWN_WRITERS[0].assert_called_once_with(  # type: ignore [attr-defined]
         filename, data, comment, **csv_options
     )
-    mock_write_csv.assert_called_once_with(filename, data, comment, encoding, **csv_options)
+    mock_write_csv.assert_called_once_with(
+        filename, data, comment, encoding, **csv_options
+    )


### PR DESCRIPTION
This PR sets UTF-8 as the default encoding when reading from or writing to file, whilst giving users the option to specify encoding when calling the top-level functions, e.g.
`data, metadata = csvy.read_to_array("important_data.csv", encoding="cp1252")`

Closes #86 