### PR TITLE
Adds a reader/writer into/from dictionaries

### DIFF
--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -306,10 +306,11 @@ def read_to_dict(
     filename: Path | str,
     marker: str = "---",
     encoding: str = "utf-8",
-    column_names: list[Any] | int | None = None,
-    fillvalue: Any = "",
     csv_options: dict[str, Any] | None = None,
     yaml_options: dict[str, Any] | None = None,
+    *,
+    column_names: list[Any] | int | None = None,
+    fillvalue: Any = "",
 ) -> tuple[dict[str, list[Any]], dict[str, Any]]:
     """Read a CSVY file into a dictionary with the header and the data as dictionaries.
 
@@ -319,12 +320,12 @@ def read_to_dict(
         filename: Name of the file to read.
         marker: The marker characters that indicate the yaml header.
         encoding: The character encoding in the file to read.
+        csv_options: Options to pass to csv.DictReader.
+        yaml_options: Options to pass to yaml.safe_load.
         column_names: Either a list with the column names, the row number containing the
             column names or None. If None (the default) an automatic column name
             ('col_0', 'col_1', ...) will be used.
         fillvalue: Value to use for missing data in the columns.
-        csv_options: Options to pass to csv.DictReader.
-        yaml_options: Options to pass to yaml.safe_load.
 
     Returns:
         Tuple containing: The data and the header both as a dictionaries.

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -335,7 +335,7 @@ def read_to_dict(
 
     longest_row = len(max(data, key=len))
     if column_names is None:
-        column_names = [f"col_{i}" for i in range(len(data[longest_row]))]
+        column_names = [f"col_{i}" for i in range(longest_row)]
     else:
         if isinstance(column_names, int):
             column_names = data.pop(column_names)

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -318,11 +318,9 @@ def read_to_dict(
         marker: The marker characters that indicate the yaml header.
         encoding: The character encoding in the file to read.
         column_names: Either a list with the column names, the row number containing the
-            column names or None. If None (the default) and a 'column_names' key is not
-            included in the header, an automatic column name ('col_0', 'col_1', ...)
-            will be used. If not None, this will override the column names indicated in
-            the header if the 'column_names' key is present.
-        fillvalue: Value to use for missing data.
+            column names or None. If None (the default) an automatic column name
+            ('col_0', 'col_1', ...) will be used.
+        fillvalue: Value to use for missing data in the columns.
         csv_options: Options to pass to csv.DictReader.
         yaml_options: Options to pass to yaml.safe_load.
 
@@ -333,8 +331,7 @@ def read_to_dict(
     data, header = read_to_list(filename, marker, encoding, csv_options, yaml_options)
 
     longest_row = len(max(data, key=len))
-    column_names = column_names or header.get("column_names", None)
-    if not column_names:
+    if column_names is None:
         column_names = [f"col_{i}" for i in range(len(data[longest_row]))]
     else:
         if isinstance(column_names, int):

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -320,7 +320,7 @@ def read_to_dict(
         filename: Name of the file to read.
         marker: The marker characters that indicate the yaml header.
         encoding: The character encoding in the file to read.
-        csv_options: Options to pass to csv.DictReader.
+        csv_options: Options to pass to csv.reader.
         yaml_options: Options to pass to yaml.safe_load.
         column_names: Either a list with the column names, the row number containing the
             column names or None. If None (the default) an automatic column name

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -313,6 +313,8 @@ def read_to_dict(
 ) -> tuple[dict[str, list[Any]], dict[str, Any]]:
     """Read a CSVY file into a dictionary with the header and the data as dictionaries.
 
+    Internally, it calls `read_to_list` and then transforms the data into a dictionary.
+
     Args:
         filename: Name of the file to read.
         marker: The marker characters that indicate the yaml header.

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -340,10 +340,10 @@ def read_to_dict(
         if isinstance(column_names, int):
             column_names = data.pop(column_names)
 
-        if len(column_names) < longest_row:
+        if len(column_names) != longest_row:
             raise ValueError(
-                "Required column names has less values than the data: "
-                f"({len({column_names})}<{longest_row})."
+                "The number of column names must be exactly the length of the longest "
+                f"row ({len({column_names})} != {longest_row})."
             )
 
     columns = list(map(list, zip_longest(*data, fillvalue=fillvalue)))

--- a/csvy/readers.py
+++ b/csvy/readers.py
@@ -310,7 +310,7 @@ def read_to_dict(
     yaml_options: dict[str, Any] | None = None,
     *,
     column_names: list[Any] | int | None = None,
-    fillvalue: Any = "",
+    fillvalue: Any = None,
 ) -> tuple[dict[str, list[Any]], dict[str, Any]]:
     """Read a CSVY file into a dictionary with the header and the data as dictionaries.
 

--- a/csvy/writers.py
+++ b/csvy/writers.py
@@ -323,7 +323,7 @@ def write_dict(
 ) -> bool:
     """Write the dictionary to the chosen file, adding it after the header.
 
-    It transofrms the dictionary into a tabular format before saving it using the
+    It transforms the dictionary into a tabular format before saving it using the
     generic `write_csv` function.
 
     Args:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -132,3 +132,47 @@ def test_read_to_list(array_data_path):
     assert len(data[0]) == 4
     assert isinstance(header, dict)
     assert len(header) > 0
+
+
+def test_read_to_dict_with_default_column_names(array_data_path):
+    """Test the read_to_list function."""
+    from csvy.readers import read_to_dict
+
+    data, header = read_to_dict(array_data_path, csv_options={"delimiter": ","})
+
+    assert isinstance(data, dict)
+    assert len(data) == 4
+    assert list(data.keys()) == ["col_0", "col_1", "col_2", "col_3"]
+    assert len(data["col_0"]) == 15
+    assert len(header) > 0
+
+
+def test_read_to_dict_with_custom_column_names(array_data_path):
+    """Test the read_to_list function."""
+    from csvy.readers import read_to_dict
+
+    column_names = ["A", "B", "C", "D"]
+    data, header = read_to_dict(
+        array_data_path, column_names=column_names, csv_options={"delimiter": ","}
+    )
+
+    assert isinstance(data, dict)
+    assert len(data) == 4
+    assert list(data.keys()) == column_names
+    assert len(data["A"]) == 15
+    assert len(header) > 0
+
+
+def test_read_to_dict_with_row_based_column_names(data_path):
+    """Test the read_to_list function."""
+    from csvy.readers import read_to_dict
+
+    data, header = read_to_dict(
+        data_path, column_names=0, csv_options={"delimiter": ","}
+    )
+
+    assert isinstance(data, dict)
+    assert len(data) == 2
+    assert list(data.keys()) == ["Date", "WTI"]
+    assert len(data["Date"]) == 15
+    assert len(header) > 0

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -138,7 +138,7 @@ def test_write_dict(mock_save, tmpdir):
     filename = tmpdir / "some_file.csv"
 
     data = {"a": [1, 2, 3, 4], "b": [1, 2, 3], "c": [1, 2, 3, 4, 5]}
-    expected_rows = max(len(v) for v in data.values()) + 1  # +1 for the column names
+    expected_rows = max(map(len, data.values())) + 1  # +1 for the column names
     assert write_dict(filename, data)
 
     mock_save.assert_called_once()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -127,6 +127,25 @@ def test_write_csv(mock_save, tmpdir):
 
 
 @patch("csv.writer")
+def test_write_dict(mock_save, tmpdir):
+    """Test the write_csv function."""
+    from csvy.writers import write_dict
+
+    class Writer:
+        writerow = MagicMock()
+
+    mock_save.return_value = Writer
+    filename = tmpdir / "some_file.csv"
+
+    data = {"a": [1, 2, 3, 4], "b": [1, 2, 3], "c": [1, 2, 3, 4, 5]}
+    expected_rows = max(len(v) for v in data.values()) + 1  # +1 for the column names
+    assert write_dict(filename, data)
+
+    mock_save.assert_called_once()
+    assert Writer.writerow.call_count == expected_rows
+
+
+@patch("csv.writer")
 @patch("csvy.writers.write_header")
 @pytest.mark.parametrize(
     "csv_options,yaml_options",


### PR DESCRIPTION
This PR adds a second option using only builtin tools by loading tabular data into a dictionary. 

The reader gives the option to manually add the column names, reading them from a row in the file or just using some default values. 

Under the hood, they both use the existing reader/writer using lists. 

Close #91 