### PR TITLE
Fix: A few missing re-exports from root module

### DIFF
--- a/csvy/__init__.py
+++ b/csvy/__init__.py
@@ -6,6 +6,8 @@ from .readers import (  # noqa: F401
     read_metadata,
     read_to_array,
     read_to_dataframe,
+    read_to_dict,
+    read_to_list,
     read_to_polars,
 )
 from .writers import Writer, write, write_header  # noqa: F401

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -79,7 +79,7 @@ def test_read_to_dataframe(data_path):
     """Test the read_to_dataframe function."""
     import pandas as pd
 
-    from csvy.readers import read_to_dataframe
+    from csvy import read_to_dataframe
 
     data, header = read_to_dataframe(data_path)
     assert isinstance(data, pd.DataFrame)
@@ -100,7 +100,7 @@ def test_read_to_polars(data_path):
     import polars as pl
     from polars.testing import assert_frame_equal
 
-    from csvy.readers import read_to_polars
+    from csvy import read_to_polars
 
     lazy_data, header = read_to_polars(data_path)
     assert isinstance(lazy_data, pl.LazyFrame)
@@ -124,7 +124,7 @@ def test_read_to_polars(data_path):
 
 def test_read_to_list(array_data_path):
     """Test the read_to_list function."""
-    from csvy.readers import read_to_list
+    from csvy import read_to_list
 
     data, header = read_to_list(array_data_path, csv_options={"delimiter": ","})
     assert isinstance(data, list)
@@ -136,7 +136,7 @@ def test_read_to_list(array_data_path):
 
 def test_read_to_dict_with_default_column_names(array_data_path):
     """Test the read_to_list function."""
-    from csvy.readers import read_to_dict
+    from csvy import read_to_dict
 
     data, header = read_to_dict(array_data_path, csv_options={"delimiter": ","})
 
@@ -149,7 +149,7 @@ def test_read_to_dict_with_default_column_names(array_data_path):
 
 def test_read_to_dict_with_custom_column_names(array_data_path):
     """Test the read_to_list function."""
-    from csvy.readers import read_to_dict
+    from csvy import read_to_dict
 
     column_names = ["A", "B", "C", "D"]
     data, header = read_to_dict(
@@ -165,7 +165,7 @@ def test_read_to_dict_with_custom_column_names(array_data_path):
 
 def test_read_to_dict_with_row_based_column_names(data_path):
     """Test the read_to_list function."""
-    from csvy.readers import read_to_dict
+    from csvy import read_to_dict
 
     data, header = read_to_dict(
         data_path, column_names=0, csv_options={"delimiter": ","}


### PR DESCRIPTION
I was playing around with things and noticed that `read_to_dict` and `read_to_list` are not re-exported from the main `csvy` package, unlike the other readers, so you have to import them from `csvy.readers` instead, which seems a bit inconsistent.

I also changed the tests for the readers to import from `csvy` rather than `csvy.readers` so we can check things are exported properly.